### PR TITLE
Add option to write env vars to spark-env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Add ability to set arbitrary environment variables in `spark-env.sh`
+
 ## 0.1.2
 
 - Fix Hadoop configuration file reference in `spark-env.sh`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [Apache Spark](https://spark.apache.org).
 ## Role Variables
 
 - `spark_version` - Spark version.
+- `spark_env_extras` - An optional dictionary with key and value attributes to add to `spark-env.sh` (e.g. `MESOS_NATIVE_LIBRARY: "/usr/local/lib/libmesos.so"`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 spark_version: "1.2.0+cdh5.3.*"
+
+spark_env_extras: {}

--- a/templates/spark-env.sh.j2
+++ b/templates/spark-env.sh.j2
@@ -75,8 +75,11 @@ fi
 
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/etc/hadoop/conf}
 
+{% for key, value in spark_env_extras.items() %}
+export {{ key }}="{{ value }}"
+{% endfor %}
+
 ### Comment above 2 lines and uncomment the following if
 ### you want to run with scala version, that is included with the package
 #export SCALA_HOME=${SCALA_HOME:-/usr/lib/spark/scala}
 #export PATH=$PATH:$SCALA_HOME/bin
-


### PR DESCRIPTION
This commit adds support for adding an arbitrary set
of environment variables to `spark-env.sh` by passing
in a list of objects with `key` and `value` attributes
by overriding the `spark_env_extras` variable when a
template inherits this template.

For example, if spark is running on top of a mesos cluster,
users of the role can override `spark_env_extras` to set the
path to the mesos native library.

``` yaml
spark_env_extras:
  MESOS_NATIVE_LIBRARY: "/usr/local/lib/libmesos.so"
```
