### PR TITLE
Bump Spark version to 1.3; add variable for Cloudera distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [Apache Spark](https://spark.apache.org).
 ## Role Variables
 
 - `spark_version` - Spark version.
+- `spark_cloudera_distribution` - Cloudera distribution version (default: `cdh5.4`)
 - `spark_env_extras` - An optional dictionary with key and value attributes to add to `spark-env.sh` (e.g. `MESOS_NATIVE_LIBRARY: "/usr/local/lib/libmesos.so"`)
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
-spark_version: "1.2.0+cdh5.3.*"
+spark_version: "1.3.0+cdh5.4.*"
+spark_cloudera_distribution: "cdh5.4"
 
 spark_env_extras: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
            state=present
 
 - name: Configure the Cloudera APT repositories
-  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-cdh5 contrib"
+  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-{{ spark_cloudera_distribution }} contrib"
                   state=present
 
 - name: Pin Cloudera APT repositories


### PR DESCRIPTION
This changeset bumps the default Spark version to 1.3 and adds a `spark_cloudera_distribution` variable that is used to determine which Cloudera package distribution channel to use.

In addition, setting `spark_cloudera_distribution` to `cdh5` will automatically pull in major Cloudera repository changes (`cdh5.3` -> `cdh5.4`).
