### PR TITLE
Divorce the Cloudera Spark distribution; embrace Apache Spark

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
-spark_version: "1.3.0+cdh5.4.*"
-spark_cloudera_distribution: "cdh5.4"
+spark_version: "1.3.1-bin-hadoop2.6"
+spark_mirror: "http://d3kbcqa49mib13.cloudfront.net"
+spark_conf_dir: "/etc/spark"
+spark_usr_dir: "/usr/lib/spark"
+spark_lib_dir: "/var/lib/spark"
+spark_log_dir: "/var/log/spark"
+spark_run_dir: "/run/spark"
 
 spark_env_extras: {}

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -17,6 +17,8 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 
+  config.vm.network "forwarded_port", guest: 4040, host: 4040
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
     ansible.sudo = true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,53 @@
 ---
-- name: Configure Cloudera APT key
-  apt_key: url="http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh/archive.key"
-           state=present
+- name: Create service account for Spark
+  user: name=spark
+        system=yes
+        home={{ spark_lib_dir }}
+        shell=/bin/false
+        state=present
 
-- name: Configure the Cloudera APT repositories
-  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-{{ spark_cloudera_distribution }} contrib"
-                  state=present
+- name: Ensure Spark configuration directory exists
+  file: path="{{ spark_conf_dir }}"
+        state=directory
 
-- name: Pin Cloudera APT repositories
-  template: src=cdh5.j2 dest=/etc/apt/preferences.d/cdh5
+- name: Ensure Spark log and run directories exist
+  file: path="{{ item }}"
+        owner=spark
+        group=spark
+        mode=0755
+        state=directory
+  with_items:
+    - "{{ spark_log_dir }}"
+    - "{{ spark_run_dir }}"
 
-- name: Install Spark
-  apt: pkg=spark-core={{ spark_version }} state=present
+- name: Download Spark distribution
+  get_url: url="{{ spark_mirror }}/spark-{{ spark_version }}.tgz"
+           dest="/usr/local/src/spark-{{ spark_version }}.tgz"
+
+- name: Extract Spark distribution
+  unarchive: src="/usr/local/src/spark-{{ spark_version }}.tgz"
+             dest="/usr/lib"
+             copy=no
+             creates="/usr/lib/spark-{{ spark_version }}"
+
+- name: Setup Spark distribution symlinks
+  file: src="{{ item.src }}"
+        dest="{{ item.dest }}"
+        state=link
+  with_items:
+    - { src: "/usr/lib/spark-{{ spark_version }}", dest: "{{ spark_usr_dir }}" }
+    - { src: "/usr/lib/spark/conf", dest: "{{ spark_conf_dir }}/conf" }
+
+- name: Create shims for Spark binaries
+  template: src=spark-shim.j2
+            dest="/usr/bin/{{ item }}"
+            mode=0755
+  with_items:
+    - spark-class
+    - spark-shell
+    - spark-sql
+    - spark-submit
 
 - name: Configure Spark environment
   template: src=spark-env.sh.j2
-            dest=/etc/spark/conf/spark-env.sh
+            dest="{{ spark_conf_dir }}/conf/spark-env.sh"

--- a/templates/cdh5.j2
+++ b/templates/cdh5.j2
@@ -1,7 +1,0 @@
-Package: *
-Pin: release n={{ ansible_distribution_release }}
-Pin-Priority: 100
-
-Package: *
-Pin: release n={{ ansible_distribution_release }}-cdh5
-Pin-Priority: 600

--- a/templates/spark-env.sh.j2
+++ b/templates/spark-env.sh.j2
@@ -15,7 +15,7 @@
 # - SPARK_PUBLIC_DNS, to set the public DNS name of the driver program
 # - SPARK_CLASSPATH, default classpath entries to append
 # - SPARK_LOCAL_DIRS, storage directories to use on this node for shuffle and RDD data
-# - MESOS_NATIVE_LIBRARY, to point to your libmesos.so if you use Mesos
+# - MESOS_NATIVE_JAVA_LIBRARY, to point to your libmesos.so if you use Mesos
 
 # Options read in YARN client mode
 # - HADOOP_CONF_DIR, to point Spark towards Hadoop configuration files
@@ -49,37 +49,13 @@
 # - SPARK_IDENT_STRING  A string representing this instance of spark. (Default: $USER)
 # - SPARK_NICENESS      The scheduling priority for daemons. (Default: 0)
 
-###
-### === IMPORTANT ===
-### Change the following to specify a real cluster's Master host
-###
-export STANDALONE_SPARK_MASTER_HOST=`hostname`
-
-export SPARK_MASTER_IP=$STANDALONE_SPARK_MASTER_HOST
-
-### Let's run everything with JVM runtime, instead of Scala
-export SPARK_LAUNCH_WITH_SCALA=0
-export SPARK_LIBRARY_PATH=${SPARK_HOME}/lib
-export SCALA_LIBRARY_PATH=${SPARK_HOME}/lib
-export SPARK_MASTER_WEBUI_PORT=18080
-export SPARK_MASTER_PORT=7077
-export SPARK_WORKER_PORT=7078
-export SPARK_WORKER_WEBUI_PORT=18081
-export SPARK_WORKER_DIR=/var/run/spark/work
-export SPARK_LOG_DIR=/var/log/spark
-export SPARK_PID_DIR='/var/run/spark/'
-
-if [ -n "$HADOOP_HOME" ]; then
-  export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libfakeroot:/usr/lib64/libfakeroot:/usr/lib32/libfakeroot:/lib/native
-fi
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/lib/hadoop/lib/native
 
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/etc/hadoop/conf}
+
+export SPARK_LOG_DIR=${SPARK_LOG_DIR:-{{ spark_log_dir }}}
+export SPARK_PID_DIR=${SPARK_PID_DIR:-{{ spark_run_dir }}}
 
 {% for key, value in spark_env_extras.items() %}
 export {{ key }}="{{ value }}"
 {% endfor %}
-
-### Comment above 2 lines and uncomment the following if
-### you want to run with scala version, that is included with the package
-#export SCALA_HOME=${SCALA_HOME:-/usr/lib/spark/scala}
-#export PATH=$PATH:$SCALA_HOME/bin

--- a/templates/spark-shim.j2
+++ b/templates/spark-shim.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "{{ spark_usr_dir }}/bin/$(basename "$0")" "$@"


### PR DESCRIPTION
These changes break backward compatibility with Spark installations supported by Cloudera. Instead, the Spark distribution is downloaded directly from Apache, and rearranged on the file system to mimic some of the structure provided by Cloudera's packages:
- Configuration in `/etc/spark/conf`
- Logs (if configured) in `/var/log/spark`
- Binaries in `/usr/bin`
- Create `spark` user

---

Testing tasks:
- [x] Make sure Spark works with the local example setup
- [x] Make sure Spark works with Mesos
