### PR TITLE
Added features (spark-defaults config and more configurable folders), fully downward compatible to original azavea.spark role

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ An Ansible role for installing [Apache Spark](https://spark.apache.org).
 - `spark_version` - Spark version.
 - `spark_cloudera_distribution` - Cloudera distribution version (default: `cdh5.4`)
 - `spark_env_extras` - An optional dictionary with key and value attributes to add to `spark-env.sh` (e.g. `MESOS_NATIVE_LIBRARY: "/usr/local/lib/libmesos.so"`)
+- `spark_defaults_extras` - An optional dictionary with key and value attributes
+  to add to `spark-defaults.conf` (e.g. `"spark.eventLog.enabled": true`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,15 @@
 ---
 spark_version: "1.3.1-bin-hadoop2.6"
 spark_mirror: "http://d3kbcqa49mib13.cloudfront.net"
+spark_src_dir: "/usr/local/src"
 spark_conf_dir: "/etc/spark"
-spark_usr_dir: "/usr/lib/spark"
+spark_usr_parent_dir: "/usr/lib"  #this is the folder where the spark archive will be extracted
+spark_usr_dir: "/usr/lib/spark"   #this is the symlink to the extracted/installed spark
 spark_lib_dir: "/var/lib/spark"
 spark_log_dir: "/var/log/spark"
 spark_run_dir: "/run/spark"
+spark_user: "spark"           # the name of the (OS)user created for spark
+spark_user_groups: []         # Optional list of (OS)groups the new spark user should belong to
 
 spark_env_extras: {}
+spark_defaults_extras: {}

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -3,6 +3,12 @@
 
   vars:
     java_version: "7u51-2.4.*"
+    spark_env_extras:
+      TEST_B: "b"
+      TEST_A: "a"
+    spark_defaults_extras:
+      "spark.eventLog.enabled": "true"
+      "spark.eventLog.disabled": "true"
 
   pre_tasks:
     - name: Update APT cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 - name: Create service account for Spark
-  user: name=spark
+  user: name={{ spark_user }}
         system=yes
         home={{ spark_lib_dir }}
         shell=/bin/false
         state=present
+        groups="{{ spark_user_groups | join(',') }}"
 
 - name: Ensure Spark configuration directory exists
   file: path="{{ spark_conf_dir }}"
@@ -12,8 +13,8 @@
 
 - name: Ensure Spark log and run directories exist
   file: path="{{ item }}"
-        owner=spark
-        group=spark
+        owner={{ spark_user }}
+        group={{ spark_user }}
         mode=0755
         state=directory
   with_items:
@@ -22,21 +23,21 @@
 
 - name: Download Spark distribution
   get_url: url="{{ spark_mirror }}/spark-{{ spark_version }}.tgz"
-           dest="/usr/local/src/spark-{{ spark_version }}.tgz"
+           dest="{{ spark_src_dir }}/spark-{{ spark_version }}.tgz"
 
 - name: Extract Spark distribution
-  unarchive: src="/usr/local/src/spark-{{ spark_version }}.tgz"
-             dest="/usr/lib"
+  unarchive: src="{{ spark_src_dir }}/spark-{{ spark_version }}.tgz"
+             dest="{{ spark_usr_parent_dir }}"
              copy=no
-             creates="/usr/lib/spark-{{ spark_version }}"
+             creates="{{ spark_usr_parent_dir }}/spark-{{ spark_version }}"
 
 - name: Setup Spark distribution symlinks
   file: src="{{ item.src }}"
         dest="{{ item.dest }}"
         state=link
   with_items:
-    - { src: "/usr/lib/spark-{{ spark_version }}", dest: "{{ spark_usr_dir }}" }
-    - { src: "/usr/lib/spark/conf", dest: "{{ spark_conf_dir }}/conf" }
+    - { src: "{{ spark_usr_parent_dir }}/spark-{{ spark_version }}", dest: "{{ spark_usr_dir }}" }
+    - { src: "{{ spark_usr_parent_dir }}/spark-{{ spark_version }}/conf", dest: "{{ spark_conf_dir }}/conf" }
 
 - name: Create shims for Spark binaries
   template: src=spark-shim.j2
@@ -51,3 +52,7 @@
 - name: Configure Spark environment
   template: src=spark-env.sh.j2
             dest="{{ spark_conf_dir }}/conf/spark-env.sh"
+
+- name: Configure Spark defaults config file
+  template: src=spark-defaults.conf.j2
+            dest="{{ spark_conf_dir }}/conf/spark-defaults.conf"

--- a/templates/spark-defaults.conf.j2
+++ b/templates/spark-defaults.conf.j2
@@ -1,0 +1,14 @@
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+# Example:
+# spark.master                     spark://master:7077
+# spark.eventLog.enabled           true
+# spark.eventLog.dir               hdfs://namenode:8021/directory
+# spark.serializer                 org.apache.spark.serializer.KryoSerializer
+# spark.driver.memory              5g
+# spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
+
+{% for key, value in spark_defaults_extras.items() | sort %}
+{{ key }} {{ value }}
+{% endfor %}

--- a/templates/spark-env.sh.j2
+++ b/templates/spark-env.sh.j2
@@ -56,6 +56,6 @@ export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/etc/hadoop/conf}
 export SPARK_LOG_DIR=${SPARK_LOG_DIR:-{{ spark_log_dir }}}
 export SPARK_PID_DIR=${SPARK_PID_DIR:-{{ spark_run_dir }}}
 
-{% for key, value in spark_env_extras.items() %}
+{% for key, value in spark_env_extras.items() | sort %}
 export {{ key }}="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
Hi
Would be great to get these features merged !
btw, I tested+used the deployment, already on multiple clusters.
greets,
Laurent

ps: I have another small feature request (I guess that has less chance for a merge, as existing configs on your side  will not work anymore): 
Transform spark_env_extras from dictionary -> list , so the original settings order is retained. (For ex. by simply using a list of strings "<env.variable>=<value>" , but I'm open for an alternative)
