### PR TITLE
skip updating an existing spark user (helps with kerberos/ldap)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
         shell=/bin/false
         state=present
         groups="{{ spark_user_groups | join(',') }}"
-  when: user_exist.stdout == 0
+  when: user_exist is defined and user_exist.stdout == 0
 
 - name: Ensure Spark configuration directory exists
   file: path="{{ spark_conf_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Check if user exists
+  action: "shell /usr/bin/getent passwd $user | /usr/bin/wc -l | tr -d ' '"
+  register: user_exist
+
 - name: Create service account for Spark
   user: name={{ spark_user }}
         system=yes
@@ -6,6 +10,7 @@
         shell=/bin/false
         state=present
         groups="{{ spark_user_groups | join(',') }}"
+  when: user_exist.stdout == 0
 
 - name: Ensure Spark configuration directory exists
   file: path="{{ spark_conf_dir }}"


### PR DESCRIPTION
because if you have the spark user managed by kerberos, the deployment fails 
when the Kerberos user attributes (like home or shell) is different from the config to be deployed by ansible
