### PR TITLE
Make use of YAML role specification format

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 if [ "up", "provision" ].include?(ARGV.first) &&
   !(File.directory?("roles/azavea.java") || File.symlink?("roles/azavea.java"))
 
-  unless system("ansible-galaxy install --force -r roles.txt -p roles")
+  unless system("ansible-galaxy install --force -r roles.yml -p roles")
     $stderr.puts "\nERROR: Please install Ansible 1.4.2+ so that the ansible-galaxy binary"
     $stderr.puts "is available."
     exit(1)

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,0 @@
-azavea.java,0.2.1

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,2 @@
+- name: azavea.java
+  version: 0.2.1


### PR DESCRIPTION
The is an attempt to silence deprecation warnings in Ansible 2.0.

---

**Testing**

``` bash
$ cd examples
$ rm -rf roles/azavea.java
$ vagrant destroy -f && vagrant up
```
