### PR TITLE
Add task to ensure that download+install dirs exists.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ spark_src_dir: "/usr/local/src"
 spark_conf_dir: "/etc/spark"
 spark_usr_parent_dir: "/usr/lib"  #this is the folder where the spark archive will be extracted
 spark_usr_dir: "/usr/lib/spark"   #this is the symlink to the extracted/installed spark
+spark_work_dir: "/usr/lib/spark/work"
+spark_tmp_dir: "/usr/lib/spark/tmp"
 spark_lib_dir: "/var/lib/spark"
 spark_log_dir: "/var/log/spark"
 spark_run_dir: "/run/spark"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,17 @@
     - spark-submit
   tags: ["shims"]
 
+- name: Ensure Spark work and temp work directories exist
+  # Execute this task after setting up the symlinks to allow directories below them
+  file: path="{{ item }}"
+        owner={{ spark_user }}
+        group={{ spark_user }}
+        mode=0775
+        state=directory
+  with_items:
+    - "{{ spark_work_dir }}"
+    - "{{ spark_tmp_dir }}"
+
 - name: Configure Spark environment
   template: src=spark-env.sh.j2
             dest="{{ spark_usr_parent_dir }}/spark-{{ spark_version }}/conf/spark-env.sh"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,14 @@
     - "{{ spark_log_dir }}"
     - "{{ spark_run_dir }}"
 
+- name: Ensure Spark download and install directories exist
+  file: path="{{ item }}"
+        mode=0755
+        state=directory
+  with_items:
+    - "{{ spark_src_dir }}"
+    - "{{ spark_usr_parent_dir }}"
+
 - name: Download Spark distribution
   get_url: url="{{ spark_mirror }}/spark-{{ spark_version }}.tgz"
            dest="{{ spark_src_dir }}/spark-{{ spark_version }}.tgz"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   file: path="{{ item }}"
         owner={{ spark_user }}
         group={{ spark_user }}
-        mode=0755
+        mode=0775
         state=directory
   with_items:
     - "{{ spark_log_dir }}"


### PR DESCRIPTION
This may be interesting if Spark is to be installed in a non-standard
location, for example alongside other versions in /opt.