### PR TITLE
fix issue if install parent dir exists and is a (dir)symlink

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
   file: path="{{ item }}"
         mode=0755
         state=directory
+        follow=true
   with_items:
     - "{{ spark_src_dir }}"
     - "{{ spark_usr_parent_dir }}"


### PR DESCRIPTION
The enabled `follow` attribute fixes following failure where `spark_usr_parent_dir:  /usr/local/tl` and 'tl' is a symlinked directory:
```
changed: [test01] => (item=/usr/local/tl/bin_repo)
failed: [test01] (item=/usr/local/tl) => {"changed": false, "failed": true, "gid": 0, "group": "root", "item": "/usr/local/tl", "mode": "0777", "msg": "/usr/local/tl already exists as a link", "owner": "root", "path": "/usr/local/tl", "size": 8, "state": "link", "uid": 0}
```
