### PR TITLE
support optional spark_local_dirs …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ spark_conf_dir: "/etc/spark"
 spark_usr_parent_dir: "/usr/lib"  #this is the folder where the spark archive will be extracted
 spark_usr_dir: "/usr/lib/spark"   #this is the symlink to the extracted/installed spark
 spark_work_dir: "/usr/lib/spark/work"
+spark_local_dirs: [] # optional list of spark-local dirs (can be used in SPARK_LOCAL_DIRS)
+spark_local_dir_mode: "1777"
 spark_tmp_dir: "/usr/lib/spark/tmp"
 spark_lib_dir: "/var/lib/spark"
 spark_log_dir: "/var/log/spark"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,16 @@
     - "{{ spark_work_dir }}"
     - "{{ spark_tmp_dir }}"
 
+- name: Ensure Spark local directories exist
+  file: path="{{ item }}"
+        owner={{ spark_user }}
+        group={{ spark_user }}
+        mode={{ spark_local_dir_mode }}
+        state=directory
+  when: item != "/tmp"
+  with_items: "{{spark_local_dirs}}"
+  tags: ["spark-local-dirs"]
+
 - name: Configure Spark environment
   template: src=spark-env.sh.j2
             dest="{{ spark_usr_parent_dir }}/spark-{{ spark_version }}/conf/spark-env.sh"

--- a/templates/spark-env.sh.j2
+++ b/templates/spark-env.sh.j2
@@ -55,6 +55,9 @@ export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/etc/hadoop/conf}
 
 export SPARK_LOG_DIR=${SPARK_LOG_DIR:-{{ spark_log_dir }}}
 export SPARK_PID_DIR=${SPARK_PID_DIR:-{{ spark_run_dir }}}
+{% if (spark_local_dirs | length) >0 %}
+export SPARK_LOCAL_DIRS=${SPARK_LOCAL_DIRS:-{{ spark_local_dirs|join(',') }}}"
+{% endif %}
 
 {% for key, value in spark_env_extras.items() | sort %}
 export {{ key }}="{{ value }}"

--- a/templates/spark-env.sh.j2
+++ b/templates/spark-env.sh.j2
@@ -56,7 +56,7 @@ export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-/etc/hadoop/conf}
 export SPARK_LOG_DIR=${SPARK_LOG_DIR:-{{ spark_log_dir }}}
 export SPARK_PID_DIR=${SPARK_PID_DIR:-{{ spark_run_dir }}}
 {% if (spark_local_dirs | length) >0 %}
-export SPARK_LOCAL_DIRS=${SPARK_LOCAL_DIRS:-{{ spark_local_dirs|join(',') }}}"
+export SPARK_LOCAL_DIRS="${SPARK_LOCAL_DIRS:-{{ spark_local_dirs|join(',') }}}"
 {% endif %}
 
 {% for key, value in spark_env_extras.items() | sort %}


### PR DESCRIPTION
… (creating the dirs and setting them in SPARK_LOCAL_DIRS in spark-env.sh)

ps: In production clusters we usually set a set of directories (each on a different disk)
feature ported from out internal spark extensions role