### PR TITLE
support for deploying hive-site.xml in the spark conf dir…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,5 +14,8 @@ spark_user: "spark"           # the name of the (OS)user created for spark
 spark_user_groups: []         # Optional list of (OS)groups the new spark user should belong to
 spark_user_shell: "/bin/false"    # the spark user's default shell
 
+spark_hive_metastore_db_installed: false
+spark_hive_site_properties: {}
+
 spark_env_extras: {}
 spark_defaults_extras: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,3 +81,6 @@
   template: src=spark-defaults.conf.j2
             dest="{{ spark_usr_parent_dir }}/spark-{{ spark_version }}/conf/spark-defaults.conf"
   tags: ["config"]
+
+- include: spark-hive-site.yml
+  tags: ["config","spark-hive-site"]

--- a/tasks/spark-hive-site.yml
+++ b/tasks/spark-hive-site.yml
@@ -2,7 +2,7 @@
 - name: Deploy hive-site.xml in spark's conf directory
   template:
     src: "templates/hive-site.xml.j2"
-    dest: "{{spark_usr_dir_orig}}/conf/hive-site.xml"
+    dest: "{{spark_usr_parent_dir}}/spark-{{spark_version}}/conf/hive-site.xml"
     force: yes
   when:
    - spark_hive_metastore_db_installed
@@ -10,7 +10,7 @@
 
 - name: Ensure hive-site.xml removed from spark's conf directory
   file:
-    path: "{{spark_usr_dir_orig}}/conf/hive-site.xml"
+    path: "{{spark_usr_parent_dir}}/spark-{{spark_version}}/conf/hive-site.xml"
     state: absent
   when:
    - not spark_hive_metastore_db_installed

--- a/tasks/spark-hive-site.yml
+++ b/tasks/spark-hive-site.yml
@@ -1,0 +1,16 @@
+---
+- name: Deploy hive-site.xml in spark's conf directory
+  template:
+    src: "templates/hive-site.xml.j2"
+    dest: "{{spark_usr_dir_orig}}/conf/hive-site.xml"
+    force: yes
+  when:
+   - spark_hive_metastore_db_installed
+   - spark_hive_site_properties|length > 0
+
+- name: Ensure hive-site.xml removed from spark's conf directory
+  file:
+    path: "{{spark_usr_dir_orig}}/conf/hive-site.xml"
+    state: absent
+  when:
+   - not spark_hive_metastore_db_installed

--- a/templates/hive-site.xml.j2
+++ b/templates/hive-site.xml.j2
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+{% if spark_hive_site_properties is defined %}
+{% for name, value in spark_hive_site_properties.items()  %}
+  <property>
+    <name>{{name}}</name>
+    <value>{{value}}</value>
+  </property>
+{% endfor %}
+{% endif %}
+</configuration>


### PR DESCRIPTION
… to configure an external database for the spark hive metastore

Example config, showing how a postgres  db can be used as a hive metastore

```
  spark_hive_metastore_db_installed: true
  spark_hive_site_properties:
    javax.jdo.option.ConnectionDriverName: "org.postgresql.Driver"
    javax.jdo.option.ConnectionURL: "{{spark_hive_metastore_db_url}}"
    javax.jdo.option.ConnectionUserName: "{{spark_hive_metastore_db_user}}"
    javax.jdo.option.ConnectionPassword: "{{spark_hive_metastore_db_pw}}"
  spark_hive_metastore_db_user: "{{postgres_user_hive_username}}"
  spark_hive_metastore_db_pw: "{{postgres_user_hive_password}}"
  spark_hive_metastore_db_host: "{{postgres_default_db_host}}"
  spark_hive_metastore_db_port: "{{postgres_default_db_port}}"
  spark_hive_metastore_db_url: "jdbc:postgresql://{{spark_hive_metastore_db_host}}:{{spark_hive_metastore_db_port}}/hive_metastore"
```
