### PR TITLE
Java role installation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [Apache Spark](https://spark.apache.org).
 ## Role Variables
 
 - `spark_version` - Spark version.
+- `spark_install_java` - flag toggling the JDK installation using the builtin azavea.java role dependency (default: `yes`)
 - `spark_cloudera_distribution` - Cloudera distribution version (default: `cdh5.4`)
 - `spark_env_extras` - An optional dictionary with key and value attributes to add to `spark-env.sh` (e.g. `MESOS_NATIVE_LIBRARY: "/usr/local/lib/libmesos.so"`)
 - `spark_defaults_extras` - An optional dictionary with key and value attributes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,5 @@ spark_hive_site_properties: {}
 
 spark_env_extras: {}
 spark_defaults_extras: {}
+
+spark_install_java: True      # Required to check if you need to install Java dependency

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 spark_version: "1.3.1-bin-hadoop2.6"
 spark_mirror: "http://d3kbcqa49mib13.cloudfront.net"
+spark_install_java: yes      # Required to check if you need to install Java dependency
+
 spark_src_dir: "/usr/local/src"
 spark_conf_dir: "/etc/spark"
 spark_usr_parent_dir: "/usr/lib"  #this is the folder where the spark archive will be extracted
@@ -21,5 +23,3 @@ spark_hive_site_properties: {}
 
 spark_env_extras: {}
 spark_defaults_extras: {}
-
-spark_install_java: yes      # Required to check if you need to install Java dependency

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,4 +22,4 @@ spark_hive_site_properties: {}
 spark_env_extras: {}
 spark_defaults_extras: {}
 
-spark_install_java: True      # Required to check if you need to install Java dependency
+spark_install_java: yes      # Required to check if you need to install Java dependency

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,4 @@ galaxy_info:
   categories:
   - system
 dependencies:
-  - { role: "azavea.java" }
+  - { role: "azavea.java",  when: spark_install_java }


### PR DESCRIPTION
Split out (3 commits of the ) the 1. (of 2) proposed features in: #20 (submitted by @darkedges )  as suggested by @tnation14 in https://github.com/azavea/ansible-spark/pull/20#pullrequestreview-102333320

Added a small refactoring commit to move the new variable near the top of the defaults variables (as IMO the 2 spark_*_extra vars should stay at the bottom, and also the java-install is happening first, when enabled.)

Additional learning, when testing out the new variable:
* (On ansible 2.4.3) Even with the variable set no/False (which correctly skips the java role install 👍 ), one still requires to have the java role installed, else the deploy fails with
```
ERROR! the role 'azavea.java' was not found in
...
The offending line appears to be:

dependencies:
  - { role: "azavea.java",  when: spark_install_java }
    ^ here
This one looks easy to fix.  It seems that there is a value started ...

```
