### PR TITLE
install of symlinks and shims can be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An Ansible role for installing [Apache Spark](https://spark.apache.org).
 
 - `spark_version` - Spark version.
 - `spark_cloudera_distribution` - Cloudera distribution version (default: `cdh5.4`)
+- `spark_symlinks_enabled` (default `yes`) - if `yes` deploy 2 symlinks (<spark_home>/conf -> /etc/spark/conf ; <spark_home> -> `spark_usr_dir` )
+- `spark_shims_enabled` (default `yes`) - if `yes` deploy the shims (like `/usr/bin/spark-shell`, `/usr/bin/spark-submit`)
 - `spark_env_extras` - An optional dictionary with key and value attributes to add to `spark-env.sh` (e.g. `MESOS_NATIVE_LIBRARY: "/usr/local/lib/libmesos.so"`)
 - `spark_defaults_extras` - An optional dictionary with key and value attributes
   to add to `spark-defaults.conf` (e.g. `"spark.eventLog.enabled": true`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,9 @@ spark_user: "spark"           # the name of the (OS)user created for spark
 spark_user_groups: []         # Optional list of (OS)groups the new spark user should belong to
 spark_user_shell: "/bin/false"    # the spark user's default shell
 
+spark_symlinks_enabled: yes
+spark_shims_enabled: yes
+
 spark_hive_metastore_db_installed: false
 spark_hive_site_properties: {}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
   with_items:
     - { src: "{{ spark_usr_parent_dir }}/spark-{{ spark_version }}", dest: "{{ spark_usr_dir }}" }
     - { src: "{{ spark_usr_parent_dir }}/spark-{{ spark_version }}/conf", dest: "{{ spark_conf_dir }}/conf" }
+  when: spark_symlinks_enabled
   tags: ["symlinks"]
 
 - name: Create shims for Spark binaries
@@ -60,6 +61,7 @@
     - spark-shell
     - spark-sql
     - spark-submit
+  when: spark_shims_enabled
   tags: ["shims"]
 
 - name: Ensure Spark work and temp work directories exist


### PR DESCRIPTION
Reason/Motivation: In case you deploy multiple spark versions, one does not want to deploy (the same) symlink for each of the deployed spark dirs

On request, I can add a commit to add the documentational one-liners in the README:
```
- `spark_symlinks_enabled` (default `yes`) - if `yes` deploy 2 symlinks (<spark_home>/conf -> /etc/spark/conf ; <spark_home> -> `spark_usr_dir` )
- `spark_shims_enabled` (default `yes`) - if `yes` deploy the shims (like `/usr/bin/spark-shell`, `/usr/bin/spark-submit`)
```
